### PR TITLE
Improved image dimension handling for older systems running legacy SSL

### DIFF
--- a/includes/wp-structuring-admin-list.php
+++ b/includes/wp-structuring-admin-list.php
@@ -62,7 +62,7 @@ class Structuring_Markup_Admin_List {
 		if ( $results ) {
 			foreach ( $results as $row ) {
 				$html  = '<tr><td>';
-				$html .= $row->activate === 'on' ? '<span class="active">Activate' : '<span class="stop">Deactivate';
+				$html .= $row->activate === 'on' ? '<span class="active">Enabled' : '<span class="stop">Disabled';
 				$html .= '</span></td>';
 				$html .= '<td><a href="';
 				$html .= admin_url( $post_url . '&type=' . esc_html( $row->type ) . '&schema_post_id=' . esc_html( $row->id ) ) . '">' . $type_array[esc_html( $row->type )];

--- a/includes/wp-structuring-admin-post.php
+++ b/includes/wp-structuring-admin-post.php
@@ -108,7 +108,7 @@ class Structuring_Markup_Admin_Post {
 		$html .= '<input type="hidden" name="id" value="'   . esc_attr( $options['id'] ) . '">';
 		$html .= '<input type="hidden" name="type" value="' . esc_attr( $options['type'] ) . '">';
 		$html .= '<table class="schema-admin-table">';
-		$html .= '<tr><th>Enable : </th><td>';
+		$html .= '<tr><th>Enabled : </th><td>';
 		$html .= '<input type="checkbox" name="activate" value="on"';
 		$html .= ( isset( $options['activate'] ) && $options['activate'] === "on" ) ? ' checked' : '';
 		$html .= '></td></tr>';

--- a/includes/wp-structuring-admin-post.php
+++ b/includes/wp-structuring-admin-post.php
@@ -80,7 +80,7 @@ class Structuring_Markup_Admin_Post {
 	 * Setting Page of the Admin Screen.
 	 *
 	 * @since   1.0.0
-	 * @version 2.2.0
+	 * @version 2.3.2
 	 * @param   array  $options
 	 * @param   string $status
 	 */
@@ -108,10 +108,10 @@ class Structuring_Markup_Admin_Post {
 		$html .= '<input type="hidden" name="id" value="'   . esc_attr( $options['id'] ) . '">';
 		$html .= '<input type="hidden" name="type" value="' . esc_attr( $options['type'] ) . '">';
 		$html .= '<table class="schema-admin-table">';
-		$html .= '<tr><th>Activate : </th><td><label>';
+		$html .= '<tr><th>Enable : </th><td>';
 		$html .= '<input type="checkbox" name="activate" value="on"';
 		$html .= ( isset( $options['activate'] ) && $options['activate'] === "on" ) ? ' checked' : '';
-		$html .= '>Activate</label></td></tr>';
+		$html .= '></td></tr>';
 		$html .= '<tr><th>' . esc_html__( 'Output Page', $this->text_domain ) . ' : </th><td>';
 		echo $html;
 

--- a/includes/wp-structuring-admin-post.php
+++ b/includes/wp-structuring-admin-post.php
@@ -4,7 +4,7 @@
  *
  * @author  Kazuya Takami
  * @since   1.0.0
- * @version 2.2.0
+ * @version 2.3.2
  */
 class Structuring_Markup_Admin_Post {
 

--- a/includes/wp-structuring-admin-type-article.php
+++ b/includes/wp-structuring-admin-type-article.php
@@ -3,7 +3,7 @@
  * Schema.org Type Article
  *
  * @author  Kazuya Takami
- * @version 2.2.0
+ * @version 2.3.2
  * @since   1.1.0
  * @see     wp-structuring-admin-db.php
  * @link    http://schema.org/Article
@@ -30,7 +30,7 @@ class Structuring_Markup_Type_Article {
 	 * Form Layout Render
 	 *
 	 * @since   1.1.0
-	 * @version 2.2.0
+	 * @version 2.3.2
 	 * @param   array $option
 	 */
 	private function page_render ( array $option ) {
@@ -76,7 +76,7 @@ class Structuring_Markup_Type_Article {
 		$html .= '<input type="text" name="option[' . "logo" . ']" id="logo" class="regular-text" required value="' . esc_attr( $option['logo'] ) . '">';
 		$html .= '<small>Default : bloginfo("logo") + "/images/logo.png"</small>';
 		$html .= '</td></tr>';
-		$html .= '<tr><th>height :</th><td><small>Auto : height >= 60px.</small></td></tr>';
+		$html .= '<tr><th>height :</th><td><small>Auto : height <= 60px.</small></td></tr>';
 		$html .= '<tr><th>width :</th><td><small>Auto : width <= 600px.</small></td></tr>';
 		$html .= '</table>';
 		echo $html;

--- a/includes/wp-structuring-admin-type-blog-posting.php
+++ b/includes/wp-structuring-admin-type-blog-posting.php
@@ -3,7 +3,7 @@
  * Schema.org Type BlogPosting
  *
  * @author  Kazuya Takami
- * @version 2.2.0
+ * @version 2.3.2
  * @since   1.2.0
  * @see     wp-structuring-admin-db.php
  * @link    http://schema.org/BlogPosting
@@ -30,7 +30,7 @@ class Structuring_Markup_Type_Blog_Posting {
 	 * Form Layout Render
 	 *
 	 * @since   1.2.0
-	 * @version 2.2.0
+	 * @version 2.3.2
 	 * @param   array $option
 	 */
 	private function page_render ( array $option ) {
@@ -76,7 +76,7 @@ class Structuring_Markup_Type_Blog_Posting {
 		$html .= '<input type="text" name="option[' . "logo" . ']" id="logo" class="regular-text" required value="' . esc_attr( $option['logo'] ) . '">';
 		$html .= '<small>Default : bloginfo("logo") + "/images/logo.png"</small>';
 		$html .= '</td></tr>';
-		$html .= '<tr><th>height :</th><td><small>Auto : height >= 60px.</small></td></tr>';
+		$html .= '<tr><th>height :</th><td><small>Auto : height <= 60px.</small></td></tr>';
 		$html .= '<tr><th>width :</th><td><small>Auto : width <= 600px.</small></td></tr>';
 		$html .= '</table>';
 		echo $html;

--- a/includes/wp-structuring-admin-type-breadcrumb.php
+++ b/includes/wp-structuring-admin-type-breadcrumb.php
@@ -3,7 +3,7 @@
  * Schema.org Type Breadcrumb
  *
  * @author  Kazuya Takami
- * @version 2.0.2
+ * @version 2.3.2
  * @since   2.0.0
  * @see     wp-structuring-admin-db.php
  * @link    https://schema.org/BreadcrumbList
@@ -28,7 +28,7 @@ class Structuring_Markup_Type_Breadcrumb {
 	/**
 	 * Form Layout Render
 	 *
-	 * @since 2.0.0
+	 * @since 2.3.2
 	 * @param array $option
 	 */
 	private function page_render ( array $option ) {
@@ -39,7 +39,7 @@ class Structuring_Markup_Type_Breadcrumb {
 		if ( isset( $option['home_on'] ) &&  $option['home_on'] === 'on' ) {
 			$html .= ' checked="checked"';
 		}
-		$html .= '>Active';
+		$html .= '>Enabled';
 		$html .= '<small>( Installed the HOME to breadcrumbs )</small>';
 		$html .= '</td></tr>';
 		$html .= '<tr><th><label for="home_name">Home Name :</label></th><td>';

--- a/includes/wp-structuring-admin-type-local-business.php
+++ b/includes/wp-structuring-admin-type-local-business.php
@@ -3,7 +3,7 @@
  * Schema.org Type Organization
  *
  * @author  Kazuya Takami
- * @since   2.3.0
+ * @since   2.3.2
  * @see     wp-structuring-admin-db.php
  * @link    http://schema.org/LocalBusiness
  * @link    https://developers.google.com/structured-data/local-businesses/
@@ -203,7 +203,7 @@ class Structuring_Markup_Type_LocalBusiness {
 	/**
 	 * Form Layout Render
 	 *
-	 * @since   2.3.0
+	 * @since   2.3.2
 	 * @param   array $option
 	 */
 	private function page_render ( array $option ) {
@@ -223,7 +223,7 @@ class Structuring_Markup_Type_LocalBusiness {
 		if ( !isset( $option['food_active'] ) ) {
 			$option['food_active'] = "";
 		}
-		$html .= $this->set_form_checkbox( 'food_active', 'Setting', $option['food_active'], 'Active' );
+		$html .= $this->set_form_checkbox( 'food_active', 'Setting', $option['food_active'], 'Enabled' );
 		$html .= $this->set_form_text( 'menu', 'Menu url', $option['menu'], false, 'For food establishments, the fully-qualified URL of the menu.' );
 		if ( !isset( $option['accepts_reservations'] ) ) {
 			$option['accepts_reservations'] = "";
@@ -249,7 +249,7 @@ class Structuring_Markup_Type_LocalBusiness {
 		if ( !isset( $option['geo_active'] ) ) {
 			$option['geo_active'] = "";
 		}
-		$html .= $this->set_form_checkbox( 'geo_active', 'Setting', $option['geo_active'], 'Active' );
+		$html .= $this->set_form_checkbox( 'geo_active', 'Setting', $option['geo_active'], 'Enabled' );
 		$html .= $this->set_form_text( 'latitude', 'Latitude', $option['latitude'], false );
 		$html .= $this->set_form_text( 'longitude', 'Longitude', $option['longitude'], false );
 		$html .= '</table>';
@@ -263,7 +263,7 @@ class Structuring_Markup_Type_LocalBusiness {
 			if ( !isset( $option[$value['type']] ) ) {
 				$option[$value['type']] = "";
 			}
-			$html .= $this->set_form_checkbox( $value['type'], $value['display'], $option[$value['type']], 'Active' );
+			$html .= $this->set_form_checkbox( $value['type'], $value['display'], $option[$value['type']], 'Enabled' );
 			$html .= $this->set_form_time( $value['type'], '', $option[$value['type'] . '-open'], $option[$value['type'] . '-close'], '' );
 		}
 

--- a/includes/wp-structuring-admin-type-news-article.php
+++ b/includes/wp-structuring-admin-type-news-article.php
@@ -3,7 +3,7 @@
  * Schema.org Type News Article
  *
  * @author  Kazuya Takami
- * @version 2.2.0
+ * @version 2.3.2
  * @since   1.0.0
  * @see     wp-structuring-admin-db.php
  * @link    http://schema.org/NewsArticle
@@ -76,7 +76,7 @@ class Structuring_Markup_Type_NewsArticle {
 		$html .= '<input type="text" name="option[' . "logo" . ']" id="logo" class="regular-text" required value="' . esc_attr( $option['logo'] ) . '">';
 		$html .= '<small>Default : bloginfo("logo") + "/images/logo.png"</small>';
 		$html .= '</td></tr>';
-		$html .= '<tr><th>height :</th><td><small>Auto : height >= 60px.</small></td></tr>';
+		$html .= '<tr><th>height :</th><td><small>Auto : height <= 60px.</small></td></tr>';
 		$html .= '<tr><th>width :</th><td><small>Auto : width <= 600px.</small></td></tr>';
 		$html .= '</table>';
 		echo $html;

--- a/includes/wp-structuring-admin-type-organization.php
+++ b/includes/wp-structuring-admin-type-organization.php
@@ -66,7 +66,7 @@ class Structuring_Markup_Type_Organization {
 	 * Form Layout Render
 	 *
 	 * @since   1.0.0
-	 * @version 2.3.0
+	 * @version 2.3.2
 	 * @param   array $option
 	 */
 	private function page_render ( array $option ) {
@@ -96,7 +96,7 @@ class Structuring_Markup_Type_Organization {
 		if ( isset( $option['contact_point'] ) &&  $option['contact_point'] === 'on' ) {
 			$html .= ' checked="checked"';
 		}
-		$html .= '>Active';
+		$html .= '>Enabled';
 		$html .= '</td></tr>';
 		$html .= '<tr><th><label for="telephone">telephone :</label></th><td>';
 		$html .= '<input type="text" name="option[' . "telephone" . ']" id="telephone" class="regular-text" value="' . esc_attr( $option['telephone'] ) . '">';

--- a/includes/wp-structuring-admin-type-website.php
+++ b/includes/wp-structuring-admin-type-website.php
@@ -3,7 +3,7 @@
  * Schema.org Type WebSite
  *
  * @author  Kazuya Takami
- * @version 1.0.0
+ * @version 2.3.2
  * @since   1.0.0
  * @see     wp-structuring-admin-db.php
  * @link    https://schema.org/WebSite
@@ -29,7 +29,7 @@ class Structuring_Markup_Type_Website {
 	/**
 	 * Form Layout Render
 	 *
-	 * @since 1.0.0
+	 * @since 2.3.2
 	 * @param array $option
 	 */
 	private function page_render ( array $option ) {
@@ -57,7 +57,7 @@ class Structuring_Markup_Type_Website {
 		if ( isset( $option['potential_action'] ) &&  $option['potential_action'] === 'on' ) {
 			$html .= ' checked="checked"';
 		}
-		$html .= '>Active';
+		$html .= '>Enabled';
 		$html .= '</td></tr>';
 		$html .= '<tr><th><label for="target">target :</label></th><td>';
 		$html .= '<input type="text" name="option[' . "target" . ']" id="target" class="regular-text" value="' . esc_attr( $option['target'] ) . '">';

--- a/includes/wp-structuring-display.php
+++ b/includes/wp-structuring-display.php
@@ -3,6 +3,7 @@
  * Schema.org Display
  *
  * @author  Kazuya Takami
+ * @author  Justin Frydman
  * @version 2.3.0
  * @since   1.0.0
  */

--- a/includes/wp-structuring-display.php
+++ b/includes/wp-structuring-display.php
@@ -132,6 +132,7 @@ class Structuring_Markup_Display {
 	 *
 	 * @since   2.3.2
 	 * @version 2.3.2
+	 * @author Justin Frydman
 	 * @param   string $url
 	 * @return  array $dimensions
 	 */
@@ -146,6 +147,8 @@ class Structuring_Markup_Display {
 	 		$curl = curl_init( $url );
 	 		curl_setopt( $curl, CURLOPT_HTTPHEADER, $headers );
 	 		curl_setopt( $curl, CURLOPT_RETURNTRANSFER, 1 );
+	 		curl_setopt( $curl, CURLOPT_SSL_VERIFYHOST, 0);
+	 		curl_setopt( $curl, CURLOPT_SSL_VERIFYPEER, 0);
 	 		$data = curl_exec( $curl );
 	 		curl_close( $curl );
 

--- a/includes/wp-structuring-display.php
+++ b/includes/wp-structuring-display.php
@@ -126,7 +126,7 @@ class Structuring_Markup_Display {
 	private function escape_text_tags ( $text ) {
 		return (string) str_replace( array( "\r", "\n" ), '', strip_tags( $text ) );
 	}
-	
+
 	/**
 	 * Return image dimensions
 	 *
@@ -139,34 +139,34 @@ class Structuring_Markup_Display {
 	 	if( $image = wp_get_attachment_image_src( attachment_url_to_postid( $url ), 'full') ) {
 	 		return array( $image[1], $image[2] );
 	 	}
-	 	
+
 	 	if( function_exists('curl_version') ) {
 	 		$headers = array('Range: bytes=0-32768');
-	 		
+
 	 		$curl = curl_init( $url );
-	 		curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
-	 		curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-	 		$data = curl_exec($curl);
-	 		curl_close($curl);
-	 		
-	 		$image = @imagecreatefromstring($data);
-	 		
-	 		if($image) {
-	 			$width  = imagesx($image);
-	 			$height = imagesy($image);
-	 			
+	 		curl_setopt( $curl, CURLOPT_HTTPHEADER, $headers );
+	 		curl_setopt( $curl, CURLOPT_RETURNTRANSFER, 1 );
+	 		$data = curl_exec( $curl );
+	 		curl_close( $curl );
+
+	 		$image = @imagecreatefromstring( $data );
+
+	 		if( $image ) {
+	 			$width  = imagesx( $image );
+	 			$height = imagesy( $image );
+
 	 			return array( $width, $height );
 	 		}
 	 	}
-	 	
+
 	 	if( $image = @getimagesize( $url ) ) {
-	 		return array( $image[0], $image[1] );	
+	 		return array( $image[0], $image[1] );
 	 	}
-	 	
+
 	 	if( $image = @getimagesize( str_replace('https://', 'http://', $url) ) ) {
 	 		return array( $image[0], $image[1] );
 	 	}
-	 	
+
 	 	return false;
 	}
 

--- a/includes/wp-structuring-display.php
+++ b/includes/wp-structuring-display.php
@@ -132,7 +132,7 @@ class Structuring_Markup_Display {
 	 *
 	 * @since   2.3.2
 	 * @version 2.3.2
-	 * @author Justin Frydman
+	 * @author  Justin Frydman
 	 * @param   string $url
 	 * @return  array $dimensions
 	 */

--- a/includes/wp-structuring-display.php
+++ b/includes/wp-structuring-display.php
@@ -140,6 +140,25 @@ class Structuring_Markup_Display {
 	 		return array( $image[1], $image[2] );
 	 	}
 	 	
+	 	if( function_exists('curl_version') ) {
+	 		$headers = array('Range: bytes=0-32768');
+	 		
+	 		$curl = curl_init( $url );
+	 		curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
+	 		curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+	 		$data = curl_exec($curl);
+	 		curl_close($curl);
+	 		
+	 		$image = @imagecreatefromstring($data);
+	 		
+	 		if($image) {
+	 			$width  = imagesx($image);
+	 			$height = imagesy($image);
+	 			
+	 			return array( $width, $height );
+	 		}
+	 	}
+	 	
 	 	if( $image = @getimagesize( $url ) ) {
 	 		return array( $image[0], $image[1] );	
 	 	}
@@ -149,7 +168,7 @@ class Structuring_Markup_Display {
 	 	}
 	 	
 	 	return false;
-	 }
+	}
 
 	/**
 	 * Setting schema.org Article

--- a/includes/wp-structuring-display.php
+++ b/includes/wp-structuring-display.php
@@ -136,12 +136,16 @@ class Structuring_Markup_Display {
 	 * @return  array $dimensions
 	 */
 	 private function get_image_dimensions ( $url ) {
-	 	if( $image = @getimagesize( $url ) ) {
-	 		return array( $image[0], $image[1]);	
+	 	if( $image = wp_get_attachment_image_src( attachment_url_to_postid( $url ), 'full') ) {
+	 		return array( $image[1], $image[2] );
 	 	}
 	 	
-	 	if( $image = wp_get_attachment_image_src( attachment_url_to_postid( $url ), 'full') ) {
-	 		return array( $image[1], $image[2]);
+	 	if( $image = @getimagesize( $url ) ) {
+	 		return array( $image[0], $image[1] );	
+	 	}
+	 	
+	 	if( $image = @getimagesize( str_replace('https://', 'http://', $url) ) ) {
+	 		return array( $image[0], $image[1] );
 	 	}
 	 	
 	 	return false;

--- a/includes/wp-structuring-display.php
+++ b/includes/wp-structuring-display.php
@@ -125,6 +125,26 @@ class Structuring_Markup_Display {
 	private function escape_text_tags ( $text ) {
 		return (string) str_replace( array( "\r", "\n" ), '', strip_tags( $text ) );
 	}
+	
+	/**
+	 * Return image dimensions
+	 *
+	 * @since   2.3.2
+	 * @version 2.3.2
+	 * @param   string $url
+	 * @return  array $dimensions
+	 */
+	 private function get_image_dimensions ( $url ) {
+	 	if( $image = @getimagesize( $url ) ) {
+	 		return array( $image[0], $image[1]);	
+	 	}
+	 	
+	 	if( $image = wp_get_attachment_image_src( attachment_url_to_postid( $url ), 'full') ) {
+	 		return array( $image[1], $image[2]);
+	 	}
+	 	
+	 	return false;
+	 }
 
 	/**
 	 * Setting schema.org Article
@@ -138,9 +158,8 @@ class Structuring_Markup_Display {
 
 		$options['logo'] = isset( $options['logo'] )  ? esc_url( $options['logo'] ) : "";
 
-		if ( has_post_thumbnail( $post->ID ) && @getimagesize( $options['logo'] ) ) {
+		if ( has_post_thumbnail( $post->ID ) && $logo = $this->get_image_dimensions( $options['logo'] ) ) {
 			$images = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' );
-			$logo   = getimagesize( $options['logo'] );
 			$excerpt = $this->escape_text_tags( $post->post_excerpt );
 			$content = $excerpt === "" ? mb_substr( $this->escape_text_tags( $post->post_content ), 0, 110 ) : $excerpt;
 
@@ -192,9 +211,8 @@ class Structuring_Markup_Display {
 
 		$options['logo'] = isset( $options['logo'] )  ? esc_url( $options['logo'] ) : "";
 
-		if ( has_post_thumbnail( $post->ID ) && @getimagesize( $options['logo'] ) ) {
+		if ( has_post_thumbnail( $post->ID ) && $logo = $this->get_image_dimensions( $options['logo'] ) ) {
 			$images = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' );
-			$logo   = getimagesize( $options['logo'] );
 			$excerpt = $this->escape_text_tags( $post->post_excerpt );
 			$content = $excerpt === "" ? mb_substr( $this->escape_text_tags( $post->post_content ), 0, 110 ) : $excerpt;
 
@@ -401,9 +419,8 @@ class Structuring_Markup_Display {
 
 		$options['logo'] = isset( $options['logo'] )  ? esc_url( $options['logo'] ) : "";
 
-		if ( has_post_thumbnail( $post->ID ) && @getimagesize( $options['logo'] ) ) {
+		if ( has_post_thumbnail( $post->ID ) && $logo = $this->get_image_dimensions( $options['logo'] ) ) {
 			$images  = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' );
-			$logo    = getimagesize( $options['logo'] );
 			$excerpt = $this->escape_text_tags( $post->post_excerpt );
 			$content = $excerpt === "" ? mb_substr( $this->escape_text_tags( $post->post_content ), 0, 110 ) : $excerpt;
 


### PR DESCRIPTION
Some systems are still running old openssl and running their website under https:// only and fetching the image with just getimagesize() will fail. This adds a number of extra ways to get images, using Wordpress' library functions and curl (if enabled), which won't download the entire image to get the dimensions. 
